### PR TITLE
Allow auto-detection of Satellite hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ On the Satellite server:
   ```
 
 4. In `vars.yml` file, update the following parameters:
-   - `satellite_hostname` - Hostname FQDN of the Satellite server.
    - `capsule_version` - Version of the capsule (`6.2` or `6.3`)to be installed.
    - `satellite_org_label` - (applicable to install only) Label of the Satellite Organization to which the capsule needs to be registered.
    - `satellite_activation_key` - (applicable to install only) Activation key of the Satellite Organization to which the capsule needs to be registered.

--- a/roles/bootstrap/tasks/main.yml
+++ b/roles/bootstrap/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Detect the hostname of Satellite
+  command: hostname
+  register: hostname
+  delegate_to: localhost
+- set_fact:
+    satellite_hostname: hostname.stdout
 - name: Get bootstrap.py
   get_url:
     url: http://{{ satellite_hostname }}/pub/bootstrap.py

--- a/vars.sample.yml
+++ b/vars.sample.yml
@@ -1,5 +1,4 @@
 ---
-satellite_hostname: changeme
 capsule_version: 6.3
 
 # Applicable only for Capsule install


### PR DESCRIPTION
The commit adds the functionality for automatically detecting
the hostname of the Satellite host and uses it for the bootstrap purpose
for capsule install/upgrade.

Signed-off-by: Saurabh Badhwar <sbadhwar@redhat.com>